### PR TITLE
add config.yml setting to overide client defaults

### DIFF
--- a/cmd/incus/alias.go
+++ b/cmd/incus/alias.go
@@ -111,7 +111,8 @@ func (c *cmdAliasList) Command() *cobra.Command {
 	cmd.Short = i18n.G("List aliases")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`List aliases`))
-	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
+	defaultFormat   := c.global.getClientDefault([]string{"alias.list.format", "format"} , "table")
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", defaultFormat, i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
 
 	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
 		return cli.ValidateFlagFormatForListOutput(cmd.Flag("format").Value.String())

--- a/cmd/incus/cluster.go
+++ b/cmd/incus/cluster.go
@@ -147,8 +147,11 @@ func (c *cmdClusterList) Command() *cobra.Command {
     s - Status
     m - Message`))
 
+	defaultFormat          := c.global.getClientDefault([]string{"cluster.list.format", "format"} , "table")
+	defaultClusterColumns  := c.global.getClientDefault([]string{"cluster.list.columns"}, defaultClusterColumns)
+
 	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", defaultClusterColumns, i18n.G("Columns")+"``")
-	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", defaultFormat, i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
 	cmd.Flags().BoolVar(&c.flagAllProjects, "all-projects", false, i18n.G("Display clusters from all projects"))
 
 	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
@@ -1092,7 +1095,9 @@ Pre-defined column shorthand chars:
   n - Name
   t - Token
   E - Expires At`))
-	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable if demanded, e.g. csv,header`)+"``")
+	defaultFormat          := c.global.getClientDefault([]string{"cluster.list-tokens.format", "format"} , "table")
+	defaultclusterTokensColumns  := c.global.getClientDefault([]string{"cluster.list-tokens.columns"}, defaultclusterTokensColumns)
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", defaultFormat, i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable if demanded, e.g. csv,header`)+"``")
 	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", defaultclusterTokensColumns, i18n.G("Columns")+"``")
 
 	cmd.RunE = c.Run

--- a/cmd/incus/cluster_group.go
+++ b/cmd/incus/cluster_group.go
@@ -482,8 +482,11 @@ Pre-defined column shorthand chars:
   d - Description
   m - Member`))
 
+	defaultFormat               := c.global.getClientDefault([]string{"cluster.group.list.format", "format"} , "table")
+	defaultClusterGroupColumns  := c.global.getClientDefault([]string{"cluster.group.list.columns"}, defaultClusterGroupColumns)
+
 	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", defaultClusterGroupColumns, i18n.G("Columns")+"``")
-	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", defaultFormat, i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
 
 	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
 		return cli.ValidateFlagFormatForListOutput(cmd.Flag("format").Value.String())

--- a/cmd/incus/config_template.go
+++ b/cmd/incus/config_template.go
@@ -287,7 +287,8 @@ func (c *cmdConfigTemplateList) Command() *cobra.Command {
 	cmd.Short = i18n.G("List instance file templates")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`List instance file templates`))
-	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
+	defaultFormat               := c.global.getClientDefault([]string{"config.template.list.format", "format"} , "table")
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", defaultFormat, i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
 
 	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
 		return cli.ValidateFlagFormatForListOutput(cmd.Flag("format").Value.String())

--- a/cmd/incus/config_trust.go
+++ b/cmd/incus/config_trust.go
@@ -421,8 +421,10 @@ Column shorthand chars:
 	r - Whether certificate is restricted
 	p - Newline-separated list of projects`))
 
-	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", "ntdfe", i18n.G("Columns")+"``")
-	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
+	defaultFormat              := c.global.getClientDefault([]string{"config.trust.list.format", "format"} , "table")
+	defaultConfigTrustColumns  := c.global.getClientDefault([]string{"config.trust.list.columns"}, "ntdfe")
+	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", defaultConfigTrustColumns, i18n.G("Columns")+"``")
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", defaultFormat, i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
 
 	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
 		return cli.ValidateFlagFormatForListOutput(cmd.Flag("format").Value.String())
@@ -613,7 +615,9 @@ Pre-defined column shorthand chars:
   n - Name
   t - Token
   E - Expires At`))
-	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
+	defaultFormat              := c.global.getClientDefault([]string{"config.trust.list-tokens.format", "format"} , "table")
+	defaultConfigTrustListTokenColumns  := c.global.getClientDefault([]string{"config.trust.list-tokens.columns"}, defaultConfigTrustListTokenColumns)
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", defaultFormat, i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
 	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", defaultConfigTrustListTokenColumns, i18n.G("Columns")+"``")
 
 	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {

--- a/cmd/incus/image.go
+++ b/cmd/incus/image.go
@@ -1090,8 +1090,12 @@ Column shorthand chars:
     u - Upload date
     t - Type`))
 
+	defaultFormat                   := c.global.getClientDefault([]string{"image.list.format", "format"} , "table")
+	defaultImagesColumns            := c.global.getClientDefault([]string{"image.list.columns"}, defaultImagesColumns)
+	defaultImagesColumnsAllProject   = c.global.getClientDefault([]string{"image.list.allprojects.columns"}, defaultImagesColumnsAllProjects)
+
 	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", defaultImagesColumns, i18n.G("Columns")+"``")
-	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", defaultFormat, i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
 	cmd.Flags().BoolVar(&c.flagAllProjects, "all-projects", false, i18n.G("Display images from all projects"))
 
 	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
@@ -1112,7 +1116,7 @@ Column shorthand chars:
 }
 
 const defaultImagesColumns = "lfpdatsu"
-const defaultImagesColumnsAllProjects = "elfpdatsu"
+var   defaultImagesColumnsAllProjects = "elfpdatsu"
 
 func (c *cmdImageList) parseColumns() ([]imageColumn, error) {
 	columnsShorthandMap := map[rune]imageColumn{

--- a/cmd/incus/image_alias.go
+++ b/cmd/incus/image_alias.go
@@ -207,7 +207,10 @@ Pre-defined column shorthand chars:
   f - Fingerprint
   t - Type
   d - Description`))
-	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
+	defaultFormat          := c.global.getClientDefault([]string{"image.alias.list.format", "format"} , "table")
+	defaultImageAliasColumns  := c.global.getClientDefault([]string{"image.alias.list.columns"}, defaultImageAliasColumns)
+
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", defaultFormat, i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
 	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", defaultImageAliasColumns, i18n.G("Columns")+"``")
 
 	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {

--- a/cmd/incus/list.go
+++ b/cmd/incus/list.go
@@ -131,9 +131,12 @@ Custom columns are defined with "[config:|devices:]key[:name][:maxWidth]":
 incus list -c ns,user.comment:comment
   List instances with their running state and user comment.`))
 
+	defaultFormat   := c.global.getClientDefault([]string{"list.format", "format"} , "table")
+	defaultColumns  := c.global.getClientDefault([]string{"list.columns"}, defaultColumns)
+
 	cmd.RunE = c.Run
 	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", defaultColumns, i18n.G("Columns")+"``")
-	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", defaultFormat, i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
 	cmd.Flags().BoolVar(&c.flagFast, "fast", false, i18n.G("Fast mode (same as --columns=nsacPt)"))
 	cmd.Flags().BoolVar(&c.flagAllProjects, "all-projects", false, i18n.G("Display instances from all projects"))
 

--- a/cmd/incus/main.go
+++ b/cmd/incus/main.go
@@ -92,6 +92,27 @@ func aliases() []string {
 	return aliases
 }
 
+func (c *cmdGlobal) getClientDefault(keys []string, defaultValue string) string {
+
+	conf := c.conf
+	var err error
+	if conf == nil || conf.Client == nil {
+		conf, err = config.LoadConfig("")
+		if err != nil {
+			return defaultValue
+		}
+	}
+
+	for _, fieldName := range keys {
+		value, ok := conf.Client[fieldName]
+		if ok {
+			return value
+		}
+	}
+
+	return defaultValue
+}
+
 func createApp() (*cobra.Command, *cmdGlobal) {
 	// Setup the parser
 	app := &cobra.Command{}

--- a/cmd/incus/network.go
+++ b/cmd/incus/network.go
@@ -1084,8 +1084,10 @@ s - State
 t - Interface type
 u - Used by (count)`))
 
+	defaultFormat   := c.global.getClientDefault([]string{"network.list.format", "format"} , "table")
+	defaultNetworkColumns  := c.global.getClientDefault([]string{"network.list.columns"}, defaultNetworkColumns)
 	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", defaultNetworkColumns, i18n.G("Columns")+"``")
-	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", defaultFormat, i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
 	cmd.Flags().BoolVar(&c.flagAllProjects, "all-projects", false, i18n.G("List networks in all projects"))
 
 	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
@@ -1289,7 +1291,9 @@ Pre-defined column shorthand chars:
   i - IP Address
   t - Type
   L - Location of the DHCP Lease (e.g. its cluster member)`))
-	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
+	defaultFormat   := c.global.getClientDefault([]string{"network.list-leases.format", "format"} , "table")
+	defaultNetworkListLeasesColumns  := c.global.getClientDefault([]string{"network.list-leases.columns"}, defaultNetworkListLeasesColumns)
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", defaultFormat, i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
 	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", defaultNetworkListLeasesColumns, i18n.G("Columns")+"``")
 
 	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {

--- a/cmd/incus/network_acl.go
+++ b/cmd/incus/network_acl.go
@@ -94,7 +94,8 @@ func (c *cmdNetworkACLList) Command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("List available network ACL"))
 
 	cmd.RunE = c.Run
-	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
+	defaultFormat   := c.global.getClientDefault([]string{"network.acl.list.format", "format"} , "table")
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", defaultFormat, i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
 	cmd.Flags().BoolVar(&c.flagAllProjects, "all-projects", false, i18n.G("List network ACLs across all projects"))
 
 	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {

--- a/cmd/incus/network_allocations.go
+++ b/cmd/incus/network_allocations.go
@@ -57,7 +57,8 @@ Pre-defined column shorthand chars:
 	cmd.Args = cobra.MaximumNArgs(1)
 	cmd.RunE = c.Run
 
-	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
+	defaultFormat   := c.global.getClientDefault([]string{"network.list-allocations.format", "format"} , "table")
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", defaultFormat, i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
 	cmd.Flags().StringVarP(&c.flagProject, "project", "p", api.ProjectDefaultName, i18n.G("Run again a specific project"))
 	cmd.Flags().BoolVar(&c.flagAllProjects, "all-projects", false, i18n.G("Run against all projects"))
 	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", defaultNetworkAllocationColumns, i18n.G("Columns")+"``")

--- a/cmd/incus/network_forward.go
+++ b/cmd/incus/network_forward.go
@@ -111,7 +111,9 @@ p - Port
 L - Location of the network zone (e.g. its cluster member)`))
 
 	cmd.RunE = c.Run
-	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
+	defaultFormat                := c.global.getClientDefault([]string{"network.forward.list.format", "format"} , "table")
+	defaultNetworkForwardColumns := c.global.getClientDefault([]string{"network.forward.list.columns"} , defaultNetworkForwardColumns)
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", defaultFormat, i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
 	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", defaultNetworkForwardColumns, i18n.G("Columns")+"``")
 
 	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {

--- a/cmd/incus/network_integration.go
+++ b/cmd/incus/network_integration.go
@@ -434,7 +434,8 @@ Pre-defined column shorthand chars:
 	t - Type
 	u - Used by`))
 
-	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
+	defaultFormat   := c.global.getClientDefault([]string{"network.integration.list.format", "format"} , "table")
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", defaultFormat, i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
 	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", defaultNetworkIntegrationColumns, i18n.G("Columns")+"``")
 
 	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {

--- a/cmd/incus/network_load_balancer.go
+++ b/cmd/incus/network_load_balancer.go
@@ -119,7 +119,8 @@ Pre-defined column shorthand chars:
   L - Location of the operation (e.g. its cluster member)`))
 
 	cmd.RunE = c.Run
-	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
+	defaultFormat   := c.global.getClientDefault([]string{"network.load-balancer.list.format", "format"} , "table")
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", defaultFormat, i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
 	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", defaultNetworkLoadBalancerColumns, i18n.G("Columns")+"``")
 
 	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {

--- a/cmd/incus/network_peer.go
+++ b/cmd/incus/network_peer.go
@@ -107,7 +107,8 @@ Pre-defined column shorthand chars:
   s - State`))
 
 	cmd.RunE = c.Run
-	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
+	defaultFormat   := c.global.getClientDefault([]string{"network.peer.list.format", "format"} , "table")
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", defaultFormat, i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
 	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", defaultNetworkPeerListColumns, i18n.G("Columns")+"``")
 
 	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {

--- a/cmd/incus/network_zone.go
+++ b/cmd/incus/network_zone.go
@@ -110,7 +110,8 @@ Pre-defined column shorthand chars:
   u - Used by`))
 
 	cmd.RunE = c.Run
-	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
+	defaultFormat   := c.global.getClientDefault([]string{"network.zone.list.format", "format"} , "table")
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", defaultFormat, i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
 	cmd.Flags().BoolVar(&c.flagAllProjects, "all-projects", false, i18n.G("Display network zones from all projects"))
 	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", defaultNetworkZoneColumns, i18n.G("Columns")+"``")
 
@@ -868,7 +869,8 @@ func (c *cmdNetworkZoneRecordList) Command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("List available network zone records"))
 
 	cmd.RunE = c.Run
-	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
+	defaultFormat   := c.global.getClientDefault([]string{"network.zone.record.list.format", "format"} , "table")
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", defaultFormat, i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
 
 	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
 		return cli.ValidateFlagFormatForListOutput(cmd.Flag("format").Value.String())

--- a/cmd/incus/operation.go
+++ b/cmd/incus/operation.go
@@ -134,7 +134,8 @@ Pre-defined column shorthand chars:
   c - Cancelable
   C - Created
   L - Location of the operation (e.g. its cluster member)`))
-	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
+	defaultFormat   := c.global.getClientDefault([]string{"operation.list.format", "format"} , "table")
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", defaultFormat, i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
 	cmd.Flags().BoolVar(&c.flagAllProjects, "all-projects", false, i18n.G("List operations from all projects")+"``")
 	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", defaultOperationColumns, i18n.G("Columns")+"``")
 

--- a/cmd/incus/profile.go
+++ b/cmd/incus/profile.go
@@ -730,8 +730,10 @@ d - Description
 u - Used By`))
 
 	cmd.RunE = c.Run
+	defaultFormat          := c.global.getClientDefault([]string{"profile.list.format", "format"} , "table")
+	defaultProfileColumns  := c.global.getClientDefault([]string{"profile.list.columns"}, defaultProfileColumns)
 	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", defaultProfileColumns, i18n.G("Columns")+"``")
-	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", defaultFormat, i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
 	cmd.Flags().BoolVar(&c.flagAllProjects, "all-projects", false, i18n.G("Display profiles from all projects"))
 
 	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {

--- a/cmd/incus/project.go
+++ b/cmd/incus/project.go
@@ -534,9 +534,11 @@ z - Network Zones
 d - Description
 u - Used By`))
 
+	defaultFormat          := c.global.getClientDefault([]string{"project.list.format", "format"} , "table")
+	defaultProjectColumns  := c.global.getClientDefault([]string{"project.list.columns"}, defaultProjectColumns)
 	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", defaultProjectColumns, i18n.G("Columns")+"``")
 
-	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", defaultFormat, i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
 
 	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
 		return cli.ValidateFlagFormatForListOutput(cmd.Flag("format").Value.String())
@@ -1062,8 +1064,9 @@ func (c *cmdProjectInfo) Command() *cobra.Command {
 	cmd.Short = i18n.G("Get a summary of resource allocations")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Get a summary of resource allocations`))
+	defaultFormat   := c.global.getClientDefault([]string{"project.info.format", "format"} , "table")
 	cmd.Flags().BoolVar(&c.flagShowAccess, "show-access", false, i18n.G("Show the instance's access list"))
-	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", defaultFormat, i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
 
 	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
 		return cli.ValidateFlagFormatForListOutput(cmd.Flag("format").Value.String())

--- a/cmd/incus/remote.go
+++ b/cmd/incus/remote.go
@@ -746,7 +746,9 @@ Pre-defined column shorthand chars:
   g - Global`))
 
 	cmd.RunE = c.Run
-	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
+	defaultFormat   := c.global.getClientDefault([]string{"remote.list.format", "format"} , "table")
+	defaultRemoteColumns  := c.global.getClientDefault([]string{"remote.list.columns"}, defaultRemoteColumns)
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", defaultFormat, i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
 	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", defaultRemoteColumns, i18n.G("Columns")+"``")
 
 	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {

--- a/cmd/incus/snapshot.go
+++ b/cmd/incus/snapshot.go
@@ -312,7 +312,8 @@ Pre-defined column shorthand chars:
   E - Expires At
   s - Stateful`))
 
-	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
+	defaultFormat   := c.global.getClientDefault([]string{"snapshot.list.format", "format"} , "table")
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", defaultFormat, i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
 	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", defaultSnapshotColumns, i18n.G("Columns")+"``")
 
 	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {

--- a/cmd/incus/storage.go
+++ b/cmd/incus/storage.go
@@ -691,9 +691,14 @@ Pre-defined column shorthand chars:
   S - Source
   u - used by
   s - state`))
+
+
+	defaultFormat          := c.global.getClientDefault([]string{"storage.list.format", "format"} , "table")
+	defaultStorageColumns  := c.global.getClientDefault([]string{"storage.list.columns"}, defaultStorageColumns)
+
 	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", defaultStorageColumns, i18n.G("Columns")+"``")
 
-	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", defaultFormat, i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
 
 	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
 		return cli.ValidateFlagFormatForListOutput(cmd.Flag("format").Value.String())

--- a/cmd/incus/storage_bucket.go
+++ b/cmd/incus/storage_bucket.go
@@ -505,7 +505,8 @@ Pre-defined column shorthand chars:
   d - Description
   L - Location of the storage bucket (e.g. its cluster member)`))
 
-	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
+	defaultFormat   := c.global.getClientDefault([]string{"storage.bucket.list.format", "format"} , "table")
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", defaultFormat, i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
 	cmd.Flags().BoolVar(&c.flagAllProjects, "all-projects", false, i18n.G("Display storage pool buckets from all projects"))
 	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", defaultStorageBucketColumns, i18n.G("Columns")+"``")
 
@@ -911,7 +912,8 @@ Pre-defined column shorthand chars:
   n - Name
   d - Description
   r - Role`))
-	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
+	defaultFormat   := c.global.getClientDefault([]string{"storage.bucket.key.list.format", "format"} , "table")
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", defaultFormat, i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
 	cmd.Flags().StringVar(&c.storageBucketKey.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", defaultStorageBucketKeyColumns, i18n.G("Columns")+"``")
 

--- a/cmd/incus/storage_volume.go
+++ b/cmd/incus/storage_volume.go
@@ -1563,7 +1563,7 @@ func (c *cmdStorageVolumeList) Command() *cobra.Command {
 	cmd.Aliases = []string{"ls"}
 	cmd.Short = i18n.G("List storage volumes")
 
-	c.defaultColumns = "etndcuL"
+	c.defaultColumns = c.global.getClientDefault([]string{"storage.volume.list.columns"} , "etndcuL")
 	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", c.defaultColumns, i18n.G("Columns")+"``")
 	cmd.Flags().BoolVar(&c.flagAllProjects, "all-projects", false, i18n.G("All projects")+"``")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
@@ -1582,7 +1582,8 @@ Column shorthand chars:
     t - Type of volume (custom, image, container or virtual-machine)
     u - Number of references (used by)
     U - Current disk usage`))
-	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
+	defaultFormat   := c.global.getClientDefault([]string{"storage.volume.list.format", "format"} , "table")
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", defaultFormat, i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
 
 	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
 		return cli.ValidateFlagFormatForListOutput(cmd.Flag("format").Value.String())
@@ -2561,7 +2562,7 @@ func (c *cmdStorageVolumeSnapshotList) Command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`List storage volume snapshots`))
 
-	c.defaultColumns = "nTE"
+	c.defaultColumns = c.global.getClientDefault([]string{"storage.volume.snapshot.list.columns"} , "nTE")
 	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", c.defaultColumns, i18n.G("Columns")+"``")
 	cmd.Flags().BoolVar(&c.flagAllProjects, "all-projects", false, i18n.G("All projects")+"``")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
@@ -2575,7 +2576,9 @@ func (c *cmdStorageVolumeSnapshotList) Command() *cobra.Command {
 		n - Name
 		T - Taken at
 		E - Expiry`))
-	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
+
+	defaultFormat   := c.global.getClientDefault([]string{"storage.volume.snapshot.list.format", "format"} , "table")
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", defaultFormat, i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
 
 	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
 		return cli.ValidateFlagFormatForListOutput(cmd.Flag("format").Value.String())

--- a/cmd/incus/top.go
+++ b/cmd/incus/top.go
@@ -60,9 +60,14 @@ Column shorthand chars:
   n - Instance name
   u - CPU usage (in seconds)`))
 
+	defaultFormat      := c.global.getClientDefault([]string{"top.format","format"} , "table")
+	if defaultFormat != "table" || defaultFormat != "compact" || defaultFormat != "lcompact" {
+		defaultFormat = "table"
+	}
+	defaultTopColumns  := c.global.getClientDefault([]string{"top.columns"}, defaultTopColumns)
 	cmd.Flags().BoolVar(&c.flagAllProjects, "all-projects", false, i18n.G("Display instances from all projects"))
 	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", defaultTopColumns, i18n.G("Columns")+"``")
-	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G("Format (table|compact)")+"``")
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", defaultFormat, i18n.G("Format (table|compact)")+"``")
 	cmd.Flags().IntVar(&c.flagRefresh, "refresh", 10, i18n.G("Configure the refresh delay in seconds")+"``")
 
 	cmd.RunE = c.Run

--- a/cmd/incus/warning.go
+++ b/cmd/incus/warning.go
@@ -91,8 +91,12 @@ Column shorthand chars:
     u - UUID
     t - Type`))
 
+
+	defaultFormat          := c.global.getClientDefault([]string{"warning.list.format", "format"} , "table")
+	defaultWarningColumns  := c.global.getClientDefault([]string{"warning.list.columns"}, defaultWarningColumns)
+
 	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", defaultWarningColumns, i18n.G("Columns")+"``")
-	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", defaultFormat, i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
 	cmd.Flags().BoolVarP(&c.flagAll, "all", "a", false, i18n.G("List all warnings")+"``")
 
 	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/table.go
+++ b/internal/cmd/table.go
@@ -22,6 +22,7 @@ const (
 	TableFormatTable   = "table"
 	TableFormatYAML    = "yaml"
 	TableFormatCompact = "compact"
+	TableFormatLCompact = "lcompact"
 )
 
 const (
@@ -57,6 +58,20 @@ func RenderTable(w io.Writer, format string, header []string, data [][]string, r
 		table.SetHeaderLine(false)
 		table.SetBorder(false)
 		table.Render()
+	case TableFormatLCompact:
+                table := getBaseTable(w, header, data)
+                table.SetAutoWrapText(false)
+                table.SetAutoFormatHeaders(true)
+                table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+                table.SetAlignment(tablewriter.ALIGN_LEFT)
+                table.SetCenterSeparator("")
+                table.SetRowSeparator("")
+                table.SetColumnSeparator("")
+                table.SetHeaderLine(false)
+                table.SetBorder(false)
+                table.SetTablePadding("\t")
+                table.SetNoWhiteSpace(true)
+                table.Render()
 	case TableFormatCSV:
 		w := csv.NewWriter(w)
 		if slices.Contains(options, TableOptionHeader) {
@@ -134,7 +149,7 @@ func ValidateFlagFormatForListOutput(value string) error {
 	}
 
 	switch format {
-	case "csv", "json", "table", "yaml", "compact":
+	case "csv", "json", "table", "yaml", "compact", "lcompact":
 	default:
 		return fmt.Errorf(`Invalid value %q for flag "--format"`, format)
 	}

--- a/shared/cliconfig/config.go
+++ b/shared/cliconfig/config.go
@@ -24,6 +24,9 @@ type Config struct {
 	// Command line aliases for `incus`
 	Aliases map[string]string `yaml:"aliases"`
 
+        // Command line default arg values
+        Client map[string]string `yaml:"client"`
+
 	// Configuration directory
 	ConfigDir string `yaml:"-"`
 

--- a/shared/cliconfig/default.go
+++ b/shared/cliconfig/default.go
@@ -35,6 +35,7 @@ func DefaultConfig() *Config {
 	return &Config{
 		Remotes:       util.CloneMap(DefaultRemotes),
 		Aliases:       make(map[string]string),
+		Client:        make(map[string]string),
 		DefaultRemote: "local",
 	}
 }


### PR DESCRIPTION
Adds a  "client" section to config.yml to store "format" and "column" defaults for list output.
Also adds a "lcompact" table format for a left justified compact option.

Should satisfy the incus Issue "CLI configuration option for default table layout #969".


Since column options vary the structure allows for command specific or general key defaults.
For example:

```
client:
   format: compact
   storage.list.format:  csv,header
   storage.list.columns: nS
```
where for all commands the default format becomes "compact" except "storage list" where the default format is "csv".

Todo tasks:
- [ ] Add "lcompact" to list help output.
- [ ] Add a incus command to manage settings

The config could be updated with an incus command like :
`incus admin client [get|set|unset] "<cmd>" "<value>"  `
`incus admin client set "storage list columns" "nS"

